### PR TITLE
Change transform listener member variable into a static variable

### DIFF
--- a/src/rosSubscriberAlgorithm.cpp
+++ b/src/rosSubscriberAlgorithm.cpp
@@ -6,10 +6,15 @@
 
 vtkStandardNewMacro(RosSubscriberAlgorithm);
 
+boost::shared_ptr<tf::TransformListener> RosSubscriberAlgorithm::tf_listener_ = nullptr;
+
 RosSubscriberAlgorithm::RosSubscriberAlgorithm()
   :new_data_(false)
 {
-  tf_listener_ = boost::make_shared<tf::TransformListener>();
+  if(!tf_listener_)
+  {
+    tf_listener_ = boost::make_shared<tf::TransformListener>();
+  }    
   sensor_to_local_transform_ = vtkSmartPointer<vtkTransform>::New();
 }
 

--- a/src/rosSubscriberAlgorithm.h
+++ b/src/rosSubscriberAlgorithm.h
@@ -37,7 +37,7 @@ protected:
   RosSubscriberAlgorithm();
   virtual ~RosSubscriberAlgorithm();
 
-  boost::shared_ptr<tf::TransformListener> tf_listener_;
+  static boost::shared_ptr<tf::TransformListener> tf_listener_;
   vtkSmartPointer<vtkTransform> sensor_to_local_transform_;
   bool new_data_;
   std::string tf_prefix_;


### PR DESCRIPTION
Instead of having one transform listener for each object ( which was a bad design I think ), the transform listener is now shared between all the instances.
It should also solve the "reset time" issue in director. It reduces a lot the cpu load of director.