### PR TITLE
replace the old tf listener with the new tf2 listener

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,10 @@ find_package(catkin REQUIRED COMPONENTS
   depth_image_utils_drs
   image_transport
   grid_map_ros
-  pcl_plugin)
+  pcl_plugin
+  tf2_geometry_msgs
+  tf2_ros
+  tf2)
 
 find_package(VTK 6.3 REQUIRED)
 include(${VTK_USE_FILE})

--- a/package.xml
+++ b/package.xml
@@ -55,6 +55,7 @@
   <depend>depth_image_utils_drs</depend>
   <depend>image_transport</depend>
   <depend>pcl_plugin</depend>
+  <depend>tf2_ros</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/src/rosSubscriberAlgorithm.cpp
+++ b/src/rosSubscriberAlgorithm.cpp
@@ -4,16 +4,20 @@
 
 #include <vtkObjectFactory.h>
 
+#include <tf2/LinearMath/Transform.h>
+
 vtkStandardNewMacro(RosSubscriberAlgorithm);
 
-boost::shared_ptr<tf::TransformListener> RosSubscriberAlgorithm::tf_listener_ = nullptr;
+boost::shared_ptr<tf2_ros::Buffer> RosSubscriberAlgorithm::tf_buffer_ = nullptr;
+boost::shared_ptr<tf2_ros::TransformListener> RosSubscriberAlgorithm::tf_listener_ = nullptr;
 
 RosSubscriberAlgorithm::RosSubscriberAlgorithm()
   :new_data_(false)
 {
   if(!tf_listener_)
   {
-    tf_listener_ = boost::make_shared<tf::TransformListener>();
+    tf_buffer_ = boost::make_shared<tf2_ros::Buffer>();
+    tf_listener_ = boost::make_shared<tf2_ros::TransformListener>(*(tf_buffer_.get()));
   }    
   sensor_to_local_transform_ = vtkSmartPointer<vtkTransform>::New();
 }
@@ -24,12 +28,19 @@ RosSubscriberAlgorithm::~RosSubscriberAlgorithm()
 
 void RosSubscriberAlgorithm::TransformBetweenFrames(const std::string& target_frame, const std::string& source_frame)
 {
-  tf::StampedTransform transform;
-
+  std::lock_guard<std::mutex> lock(tf_mutex_);
+  geometry_msgs::TransformStamped transform;
   // return the latest transform between target_frame and source_frame
-  tf_listener_->lookupTransform(target_frame, source_frame, ros::Time(0), transform);
+  try {
+    transform = tf_buffer_->lookupTransform(target_frame, source_frame, ros::Time(0));
+  }  catch (tf2::TransformException &ex) {
+    ROS_WARN("TF lookupTransform exception : %s",ex.what());
+    return;
+  }
 
-  sensor_to_local_transform_ = transformPolyDataUtils::transformFromPose(transform);
+  tf::Transform tf_transform;
+  tf::transformMsgToTF (transform.transform, tf_transform);
+  sensor_to_local_transform_ = transformPolyDataUtils::transformFromPose(tf_transform);
 }
 
 void RosSubscriberAlgorithm::PrintSelf(ostream& os, vtkIndent indent)
@@ -39,7 +50,14 @@ void RosSubscriberAlgorithm::PrintSelf(ostream& os, vtkIndent indent)
 
 void RosSubscriberAlgorithm::ResetTime()
 {
-  tf_listener_->clear();
+  // TODO : with the old tf_listener there was a "clear" method that doesn't exist anymore.
+  // The awkward following steps are to reset it, is there a better way to do that ?
+  std::lock_guard<std::mutex> lock(tf_mutex_);
+  tf_listener_.reset();
+  tf_buffer_.reset();
+  tf_buffer_ = boost::make_shared<tf2_ros::Buffer>();
+  tf_listener_ = boost::make_shared<tf2_ros::TransformListener>(*(tf_buffer_.get()));
+
 }
 
 void RosSubscriberAlgorithm::SetTFPrefix(std::string prefix){

--- a/src/rosSubscriberAlgorithm.h
+++ b/src/rosSubscriberAlgorithm.h
@@ -1,9 +1,12 @@
 #ifndef ROSSUBSCRIBERALGORITHM_H
 #define ROSSUBSCRIBERALGORITHM_H
 
+#include <mutex>
+
 #include <boost/shared_ptr.hpp>
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <vtkDRCFiltersModule.h>
 #include <vtkSmartPointer.h>
@@ -37,7 +40,9 @@ protected:
   RosSubscriberAlgorithm();
   virtual ~RosSubscriberAlgorithm();
 
-  static boost::shared_ptr<tf::TransformListener> tf_listener_;
+  static boost::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  static boost::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::mutex tf_mutex_;
   vtkSmartPointer<vtkTransform> sensor_to_local_transform_;
   bool new_data_;
   std::string tf_prefix_;


### PR DESCRIPTION
@heuristicus 
https://wiki.ros.org/tf2/Migration
http://wiki.ros.org/tf2/Tutorials/Writing%20a%20tf2%20listener%20%28C%2B%2B%29
In theory it should reduce the cpu load. I will try to replace all the tf_listener in director.
I have tested it. The reset feature works. Feel free to test it too !